### PR TITLE
Add SocketAddress-based API and deprecate string-based one

### DIFF
--- a/ESP32Interface.h
+++ b/ESP32Interface.h
@@ -57,11 +57,16 @@ public:
      *  Implicitly disables DHCP, which can be enabled in set_dhcp.
      *  Requires that the network is disconnected.
      *
-     *  @param ip_address Null-terminated representation of the local IP address
-     *  @param netmask    Null-terminated representation of the local network mask
-     *  @param gateway    Null-terminated representation of the local gateway
+     *  @param ip_address SocketAddress representation of the local IP address
+     *  @param netmask    SocketAddress representation of the local network mask
+     *  @param gateway    SocketAddress representation of the local gateway
      *  @return           0 on success, negative error code on failure
      */
+    virtual nsapi_error_t set_network(
+            const SocketAddress &ip_address, const SocketAddress &netmask,
+            const SocketAddress &gateway) override;
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual nsapi_error_t set_network(
             const char *ip_address, const char *netmask, const char *gateway);
 
@@ -123,8 +128,15 @@ public:
     virtual int disconnect();
 
     /** Get the internally stored IP address
-     *  @return             IP address of the interface or null if not yet connected
+     *  @param          sockAddr SocketAddress pointer to store the local IP address
+     *  @retval         NSAPI_ERROR_OK on success
+     *  @retval         NSAPI_ERROR_UNSUPPORTED if this feature is not supported
+     *  @retval         NSAPI_ERROR_PARAMETER if the provided pointer is invalid
+     *  @retval         NSAPI_ERROR_NO_ADDRESS if the address cannot be obtained from stack
      */
+    virtual nsapi_error_t get_ip_address(SocketAddress *sockAddr);
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_ip_address();
 
     /** Get the internally stored MAC address
@@ -134,16 +146,28 @@ public:
 
      /** Get the local gateway
      *
-     *  @return         Null-terminated representation of the local gateway
-     *                  or null if no network mask has been recieved
+     *  @param          sockAddr SocketAddress representation of gateway address
+     *  @retval         NSAPI_ERROR_OK on success
+     *  @retval         NSAPI_ERROR_UNSUPPORTED if this feature is not supported
+     *  @retval         NSAPI_ERROR_PARAMETER if the provided pointer is invalid
+     *  @retval         NSAPI_ERROR_NO_ADDRESS if the address cannot be obtained from stack
      */
+    virtual nsapi_error_t get_gateway(SocketAddress *sockAddr);
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_gateway();
 
     /** Get the local network mask
      *
-     *  @return         Null-terminated representation of the local network mask
-     *                  or null if no network mask has been recieved
+     *  @param          sockAddr SocketAddress representation of netmask
+     *  @retval         NSAPI_ERROR_OK on success
+     *  @retval         NSAPI_ERROR_UNSUPPORTED if this feature is not supported
+     *  @retval         NSAPI_ERROR_PARAMETER if the provided pointer is invalid
+     *  @retval         NSAPI_ERROR_NO_ADDRESS if the address cannot be obtained from stack
      */
+    virtual nsapi_error_t get_netmask(SocketAddress *sockAddr);
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_netmask();
 
     /** Gets the current radio signal strength for active connection
@@ -221,9 +245,9 @@ private:
     char _ap_ssid[33]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     char _ap_pass[64]; /* The longest allowed passphrase */
     nsapi_security_t _ap_sec;
-    char _ip_address[NSAPI_IPv6_SIZE];
-    char _netmask[NSAPI_IPv4_SIZE];
-    char _gateway[NSAPI_IPv4_SIZE];
+    SocketAddress _ip_address;
+    SocketAddress _netmask;
+    SocketAddress _gateway;
     nsapi_connection_status_t _connection_status;
     Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 

--- a/ESP32InterfaceAP.cpp
+++ b/ESP32InterfaceAP.cpp
@@ -65,16 +65,23 @@ ESP32InterfaceAP::ESP32InterfaceAP(PinName tx, PinName rx, bool debug) :
 {
 }
 
+nsapi_error_t ESP32InterfaceAP::set_network(const SocketAddress &ip_address, const SocketAddress &netmask, const SocketAddress &gateway)
+{
+    _dhcp = false;
+    _ip_address = ip_address;
+    _netmask = netmask;
+    _gateway = gateway;
+
+    return NSAPI_ERROR_OK;
+}
+
 nsapi_error_t ESP32InterfaceAP::set_network(const char *ip_address, const char *netmask, const char *gateway)
 {
     _dhcp = false;
 
-    strncpy(_ip_address, ip_address ? ip_address : "", sizeof(_ip_address));
-    _ip_address[sizeof(_ip_address) - 1] = '\0';
-    strncpy(_netmask, netmask ? netmask : "", sizeof(_netmask));
-    _netmask[sizeof(_netmask) - 1] = '\0';
-    strncpy(_gateway, gateway ? gateway : "", sizeof(_gateway));
-    _gateway[sizeof(_gateway) - 1] = '\0';
+    _ip_address.set_ip_address(ip_address);
+    _netmask.set_ip_address(netmask);
+    _gateway.set_ip_address(gateway);
 
     return NSAPI_ERROR_OK;
 }
@@ -115,7 +122,7 @@ int ESP32InterfaceAP::connect()
     }
 
     if (!_dhcp) {
-        if (!_esp->set_network_ap(_ip_address, _netmask, _gateway)) {
+        if (!_esp->set_network_ap(_ip_address.get_ip_address(), _netmask.get_ip_address(), _gateway.get_ip_address())) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
     }
@@ -179,6 +186,14 @@ int ESP32InterfaceAP::disconnect()
     return NSAPI_ERROR_OK;
 }
 
+nsapi_error_t ESP32InterfaceAP::get_ip_address(SocketAddress* sockAddr)
+{
+    if (sockAddr->set_ip_address(_esp->getIPAddress_ap())) {
+        return NSAPI_ERROR_OK;
+    }
+    return NSAPI_ERROR_NO_ADDRESS;
+}
+
 const char *ESP32InterfaceAP::get_ip_address()
 {
     return _esp->getIPAddress_ap();
@@ -189,10 +204,27 @@ const char *ESP32InterfaceAP::get_mac_address()
     return _esp->getMACAddress_ap();
 }
 
+nsapi_error_t ESP32InterfaceAP::get_gateway(SocketAddress* sockAddr)
+{
+    if (sockAddr->set_ip_address(_esp->getGateway_ap())) {
+        return NSAPI_ERROR_OK;
+    }
+    return NSAPI_ERROR_NO_ADDRESS;
+}
+
 const char *ESP32InterfaceAP::get_gateway()
 {
     return _esp->getGateway_ap();
 }
+
+nsapi_error_t ESP32InterfaceAP::get_netmask(SocketAddress* sockAddr)
+{
+    if (sockAddr->set_ip_address(_esp->getNetmask_ap())) {
+        return NSAPI_ERROR_OK;
+    }
+    return NSAPI_ERROR_NO_ADDRESS;
+}
+
 
 const char *ESP32InterfaceAP::get_netmask()
 {

--- a/ESP32InterfaceAP.h
+++ b/ESP32InterfaceAP.h
@@ -58,11 +58,16 @@ public:
      *  Implicitly disables DHCP, which can be enabled in set_dhcp.
      *  Requires that the network is disconnected.
      *
-     *  @param ip_address Null-terminated representation of the local IP address
-     *  @param netmask    Null-terminated representation of the local network mask
-     *  @param gateway    Null-terminated representation of the local gateway
+     *  @param ip_address SocketAddress representation of the local IP address
+     *  @param netmask    SocketAddress representation of the local network mask
+     *  @param gateway    SocketAddress representation of the local gateway
      *  @return           0 on success, negative error code on failure
      */
+    virtual nsapi_error_t set_network(
+            const SocketAddress &ip_address, const SocketAddress &netmask,
+            const SocketAddress &gateway) override;
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual nsapi_error_t set_network(
             const char *ip_address, const char *netmask, const char *gateway);
 
@@ -124,8 +129,16 @@ public:
     virtual int disconnect();
 
     /** Get the internally stored IP address
-     *  @return             IP address of the interface or null if not yet connected
+     *
+     *  @param          address SocketAddress pointer to store the local IP address
+     *  @retval         NSAPI_ERROR_OK on success
+     *  @retval         NSAPI_ERROR_UNSUPPORTED if this feature is not supported
+     *  @retval         NSAPI_ERROR_PARAMETER if the provided pointer is invalid
+     *  @retval         NSAPI_ERROR_NO_ADDRESS if the address cannot be obtained from stack
      */
+    virtual nsapi_error_t get_ip_address(SocketAddress *address);
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_ip_address();
 
     /** Get the internally stored MAC address
@@ -135,16 +148,28 @@ public:
 
      /** Get the local gateway
      *
-     *  @return         Null-terminated representation of the local gateway
-     *                  or null if no network mask has been recieved
+     *  @param          address SocketAddress representation of gateway address
+     *  @retval         NSAPI_ERROR_OK on success
+     *  @retval         NSAPI_ERROR_UNSUPPORTED if this feature is not supported
+     *  @retval         NSAPI_ERROR_PARAMETER if the provided pointer is invalid
+     *  @retval         NSAPI_ERROR_NO_ADDRESS if the address cannot be obtained from stack
      */
+    virtual nsapi_error_t get_gateway(SocketAddress *address);
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_gateway();
 
     /** Get the local network mask
      *
-     *  @return         Null-terminated representation of the local network mask
-     *                  or null if no network mask has been recieved
+     *  @param          address SocketAddress representation of netmask
+     *  @retval         NSAPI_ERROR_OK on success
+     *  @retval         NSAPI_ERROR_UNSUPPORTED if this feature is not supported
+     *  @retval         NSAPI_ERROR_PARAMETER if the provided pointer is invalid
+     *  @retval         NSAPI_ERROR_NO_ADDRESS if the address cannot be obtained from stack
      */
+    virtual nsapi_error_t get_netmask(SocketAddress *address);
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_netmask();
 
     /** Gets the current radio signal strength for active connection
@@ -224,9 +249,9 @@ private:
     char _own_ssid[33]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     char _own_pass[64]; /* The longest allowed passphrase */
     nsapi_security_t _own_sec;
-    char _ip_address[NSAPI_IPv6_SIZE];
-    char _netmask[NSAPI_IPv4_SIZE];
-    char _gateway[NSAPI_IPv4_SIZE];
+    SocketAddress _ip_address;
+    SocketAddress _netmask;
+    SocketAddress _gateway;
     nsapi_connection_status_t _connection_status;
     Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 };


### PR DESCRIPTION
[As of mbed-os-5.15](https://github.com/ARMmbed/mbed-os/pull/11914) the string-based APIs are deprecated.
This PR adds the deprecation warning and introduces the new SocketAddress-based API.

@d-kato , @toyowata , @0xc0170 , @AnttiKauppila  please review.

Please, also note, that [as of mbed-os-6.0 the string-based API will be completely removed](https://github.com/ARMmbed/mbed-os/pull/11942).

As a side note - could we add some information in https://github.com/d-kato/esp32-driver repository, explaining that it is no longer maintained and has been moved to ARMmbed? @d-kato ?
