### PR TITLE
Add reset for re-connect

### DIFF
--- a/ESP32/ESP32.cpp
+++ b/ESP32/ESP32.cpp
@@ -24,6 +24,8 @@
 
 using namespace mbed;
 using namespace rtos;
+using namespace std::chrono;
+using std::milli;
 
 ESP32 * ESP32::instESP32 = NULL;
 
@@ -191,7 +193,7 @@ void ESP32::_startup_common()
     }
     if (_p_wifi_en != NULL) {
         _p_wifi_en->write(0);
-        ThisThread::sleep_for(10);
+        ThisThread::sleep_for(10ms);
         _p_wifi_en->write(1);
         _parser.recv("ready");
     } else {
@@ -351,7 +353,7 @@ bool ESP32::accept(int * p_id)
         }
         _smutex.unlock();
         if (!ret) {
-            ThisThread::sleep_for(5);
+            ThisThread::sleep_for(5ms);
         }
     }
 
@@ -392,7 +394,7 @@ bool ESP32::reset(void)
 #endif
             }
 
-            ThisThread::sleep_for(5);
+            ThisThread::sleep_for(5ms);
 
             uint8_t wk_ver[4+1]; /* It needs 1 byte extra. */
 
@@ -654,7 +656,7 @@ int ESP32::scan(WiFiAccessPoint *res, unsigned limit)
         _smutex.lock();
         _startup_wifi();
         _smutex.unlock();
-        ThisThread::sleep_for(1500);
+        ThisThread::sleep_for(1500ms);
     }
 
     _smutex.lock();
@@ -1108,6 +1110,14 @@ int8_t ESP32::get_wifi_status() const
 {
     return _wifi_status;
 }
+
+void ESP32::flush()
+{
+    _smutex.lock();
+    _parser.flush();
+    _smutex.unlock();
+}
+
 
 #if defined(TARGET_ESP32AT_BLE)
 bool ESP32::ble_set_role(int role)

--- a/ESP32/ESP32.h
+++ b/ESP32/ESP32.h
@@ -246,6 +246,15 @@ public:
      */
     int8_t get_wifi_status() const;
 
+    /**
+     * Flush the serial port input buffers.
+     *
+     * If you do HW reset for ESP module, you should
+     * flush the input buffers from existing responses
+     * from the device.
+     */
+    void flush();
+
     static const int8_t WIFIMODE_STATION = 1;
     static const int8_t WIFIMODE_SOFTAP = 2;
     static const int8_t WIFIMODE_STATION_SOFTAP = 3;
@@ -352,11 +361,11 @@ public:
     typedef struct {
         uint16_t  adv_int_min;       /**< minimum value of advertising interval; range: 0x0020 ~ 0x4000 */
         uint16_t  adv_int_max;       /**< maximum value of advertising interval; range: 0x0020 ~ 0x4000 */
-        uint8_t   adv_type;          /**< 0：ADV_TYPE_IND, 2：ADV_TYPE_SCAN_IND, 3：ADV_TYPE_NONCONN_IND */
-        uint8_t   own_addr_type;     /**< own BLE address type; 0：BLE_ADDR_TYPE_PUBLIC, 1：BLE_ADDR_TYPE_RANDOM */
+        uint8_t   adv_type;          /**< 0:FADV_TYPE_IND, 2:FADV_TYPE_SCAN_IND, 3:FADV_TYPE_NONCONN_IND */
+        uint8_t   own_addr_type;     /**< own BLE address type; 0:FBLE_ADDR_TYPE_PUBLIC, 1:FBLE_ADDR_TYPE_RANDOM */
         uint8_t   channel_map;       /**< channel of advertising; ADV_CHNL_~ */
         uint8_t   adv_filter_policy; /**< filter policy of advertising; ADV_FILTER_ALLOW_SCAN_~ */
-        uint8_t   peer_addr_type;    /**< remote BLE address type; 0：PUBLIC, 1：RANDOM */
+        uint8_t   peer_addr_type;    /**< remote BLE address type; 0:FPUBLIC, 1:FRANDOM */
         uint8_t   peer_addr[6];      /**< remote BLE address */
     } advertising_param_t;
 

--- a/ESP32/ESP32.h
+++ b/ESP32/ESP32.h
@@ -34,10 +34,10 @@
 #include "rtos/Mutex.h"
 #include "rtos/ThisThread.h"
 
-#if (MBED_MAJOR_VERSION >= 6)
-#include "drivers/BufferedSerial.h"
-#else
+#if (MBED_MAJOR_VERSION < 6)
 #include "drivers/UARTSerial.h"
+#else
+#include "drivers/BufferedSerial.h"
 #endif
 
 #ifndef ESP32_CONNECT_TIMEOUT
@@ -275,10 +275,10 @@ private:
     mbed::DigitalOut * _p_wifi_io0;
     bool _init_end_common;
     bool _init_end_wifi;
-#if (MBED_MAJOR_VERSION >= 6)
-    mbed::BufferedSerial _serial;
-#else
+#if (MBED_MAJOR_VERSION < 6)
     mbed::UARTSerial _serial;
+#else
+    mbed::BufferedSerial _serial;
 #endif
     mbed::ATCmdParser _parser;
     struct packet {

--- a/ESP32/ESP32.h
+++ b/ESP32/ESP32.h
@@ -24,15 +24,21 @@
 #include <stdlib.h>
 #include "drivers/DigitalOut.h"
 #include "drivers/SerialBase.h"
-#include "drivers/BufferedSerial.h"
 #include "features/netsocket/nsapi_types.h"
 #include "features/netsocket/WiFiAccessPoint.h"
 #include "PinNames.h"
 #include "platform/ATCmdParser.h"
 #include "platform/Callback.h"
 #include "platform/mbed_error.h"
+#include "platform/mbed_version.h"
 #include "rtos/Mutex.h"
 #include "rtos/ThisThread.h"
+
+#if (MBED_MAJOR_VERSION >= 6)
+#include "drivers/BufferedSerial.h"
+#else
+#include "drivers/UARTSerial.h"
+#endif
 
 #ifndef ESP32_CONNECT_TIMEOUT
 #define ESP32_CONNECT_TIMEOUT 15000
@@ -269,7 +275,11 @@ private:
     mbed::DigitalOut * _p_wifi_io0;
     bool _init_end_common;
     bool _init_end_wifi;
+#if (MBED_MAJOR_VERSION >= 6)
     mbed::BufferedSerial _serial;
+#else
+    mbed::UARTSerial _serial;
+#endif
     mbed::ATCmdParser _parser;
     struct packet {
         struct packet *next;

--- a/ESP32Interface.h
+++ b/ESP32Interface.h
@@ -44,6 +44,11 @@ public:
     ESP32Interface(PinName en, PinName io0, PinName tx, PinName rx, bool debug = false,
                    PinName rts = NC, PinName cts = NC, int baudrate = 230400);
 
+    /**
+     * @brief ESP32Interface default destructor
+     */
+    virtual ~ESP32Interface();
+
     /** ESP32Interface lifetime
      * @param tx        TX pin
      * @param rx        RX pin
@@ -241,6 +246,19 @@ public:
     }
 
 private:
+
+    // HW reset pin
+    class ResetPin {
+    public:
+        ResetPin(PinName rst_pin);
+        void rst_assert();
+        void rst_deassert();
+        bool is_connected();
+    private:
+        mbed::DigitalOut  _rst_pin;
+    } _rst_pin;
+
+    int _initialized;
     bool _dhcp;
     char _ap_ssid[33]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     char _ap_pass[64]; /* The longest allowed passphrase */
@@ -249,10 +267,12 @@ private:
     SocketAddress _netmask;
     SocketAddress _gateway;
     nsapi_connection_status_t _connection_status;
-    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
+    mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 
     void set_connection_status(nsapi_connection_status_t connection_status);
     void wifi_status_cb(int8_t wifi_status);
+    nsapi_error_t _init(void);
+    nsapi_error_t _reset(void);
 };
 
 #endif


### PR DESCRIPTION
* Add module reset function
* Add support Mbed OS 5

Test result by mbed-os-example-wifi on Renesas GR-LYCHEE:

```
WiFi example
Mbed OS version 6.1.0

Scan:
Network: Buffalo-G-xxxx secured: WPA/WPA2 BSSID: 34:3D:C4:xx:xx:xx RSSI: -49 Ch: 8
Network: elecom2g-xxxxx secured: WPA2 BSSID: BC:5C:4C:xx:xx:xx RSSI: -82 Ch: 9
Network: SPWN_H37_xxxxxx secured: WPA/WPA2 BSSID: F0:E4:A2:xx:xx:xx RSSI: -89 Ch: 10
3 networks available.

Connecting to Buffalo-G-xxxx...
Success

MAC: 30:ae:a4:xx:xx:xx
IP: 192.168.11.24
Netmask: 255.255.255.0
Gateway: 192.168.11.1
RSSI: 0


Done
```
