### PR TITLE
Update netsocket header reference path in ESP header

### DIFF
--- a/ESP32/ESP32.h
+++ b/ESP32/ESP32.h
@@ -24,8 +24,8 @@
 #include <stdlib.h>
 #include "drivers/DigitalOut.h"
 #include "drivers/SerialBase.h"
-#include "features/netsocket/nsapi_types.h"
-#include "features/netsocket/WiFiAccessPoint.h"
+#include "netsocket/nsapi_types.h"
+#include "netsocket/WiFiAccessPoint.h"
 #include "PinNames.h"
 #include "platform/ATCmdParser.h"
 #include "platform/Callback.h"


### PR DESCRIPTION
- As part of Mbed OS netsocket directory restructuringall the headers moved from
 `features/netsocket` => `connectivity/netsocket/include/netsocket`, so updated the header reference in the esp header file.

PR for netsocket directory restructure:  https://github.com/ARMmbed/mbed-os/pull/13335 

### Reviewers <!-- Optional -->
@jamesbeyond @paul-szczepanek-arm 